### PR TITLE
adds support to jq expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ OPTIONS:
    --match value             exact|superset (default: "exact")
    --threads value           10 (default: "4")
    --loglevel value          info (default: "debug")
+   --jq value                jq expression executed in compared data
 ```
 
 ## CSV File 

--- a/diff/assert.go
+++ b/diff/assert.go
@@ -110,24 +110,9 @@ func newOutput(ctx context.Context, c httpClient, i input, jq *gojq.Query) (outp
 		if err != nil {
 			return o, err
 		}
-		iter := jq.Run(body)
-		qres := []interface{}{}
-		for {
-			v, ok := iter.Next()
-			if !ok {
-				break
-			}
-			if err, ok := v.(error); ok {
-				return o, err
-			}
-			qres = append(qres, v)
-		}
-		qresJson, err := json.Marshal(qres)
+		o.Body, err = applyJqQueryToBody(jq, body)
 		if err != nil {
 			return o, err
-		}
-		o.Body = map[string]json.RawMessage{
-			"jq": qresJson,
 		}
 	} else {
 		err = json.NewDecoder(resp.Body).Decode(&o.Body)

--- a/diff/assert.go
+++ b/diff/assert.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/arithran/jsondiff"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/itchyny/gojq"
 )
 
 var opts jsondiff.Options
@@ -25,17 +26,18 @@ type (
 	}
 )
 
-func exec(ctx context.Context, c httpClient, t test, ignore map[string]struct{}, wantMatch jsondiff.Difference) (result, error) {
+func exec(ctx context.Context, c httpClient, t test,
+	ignore map[string]struct{}, wantMatch jsondiff.Difference, jq *gojq.Query) (result, error) {
 	var err error
 	res := result{
 		e: t,
 	}
 
-	res.Before, err = newOutput(ctx, c, t.Before)
+	res.Before, err = newOutput(ctx, c, t.Before, jq)
 	if err != nil {
 		return res, err
 	}
-	res.After, err = newOutput(ctx, c, t.After)
+	res.After, err = newOutput(ctx, c, t.After, jq)
 	if err != nil {
 		return res, err
 	}
@@ -73,7 +75,7 @@ type output struct {
 	Body map[string]json.RawMessage
 }
 
-func newOutput(ctx context.Context, c httpClient, i input) (output, error) {
+func newOutput(ctx context.Context, c httpClient, i input, jq *gojq.Query) (output, error) {
 	o := output{}
 
 	// request
@@ -101,11 +103,38 @@ func newOutput(ctx context.Context, c httpClient, i input) (output, error) {
 
 	// decode
 	o.Code = resp.Status
-	err = json.NewDecoder(resp.Body).Decode(&o.Body)
-	if err != nil {
-		return o, err
+	defer resp.Body.Close()
+	if jq != nil {
+		var body interface{}
+		err = json.NewDecoder(resp.Body).Decode(&body)
+		if err != nil {
+			return o, err
+		}
+		iter := jq.Run(body)
+		qres := []interface{}{}
+		for {
+			v, ok := iter.Next()
+			if !ok {
+				break
+			}
+			if err, ok := v.(error); ok {
+				return o, err
+			}
+			qres = append(qres, v)
+		}
+		qresJson, err := json.Marshal(qres)
+		if err != nil {
+			return o, err
+		}
+		o.Body = map[string]json.RawMessage{
+			"jq": qresJson,
+		}
+	} else {
+		err = json.NewDecoder(resp.Body).Decode(&o.Body)
+		if err != nil {
+			return o, err
+		}
 	}
-	resp.Body.Close()
 
 	return o, nil
 }

--- a/diff/assert_test.go
+++ b/diff/assert_test.go
@@ -22,7 +22,7 @@ func Test_newOutput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := newOutput(tt.args.ctx, tt.args.c, tt.args.i)
+			got, err := newOutput(tt.args.ctx, tt.args.c, tt.args.i, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("newOutput() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/diff/jq.go
+++ b/diff/jq.go
@@ -1,0 +1,77 @@
+package diff
+
+import (
+	"encoding/json"
+
+	"github.com/itchyny/gojq"
+)
+
+// jqMatchesToBody converts a list of jq matches to a diff-able object.
+// jq matches might not be a valid json, which would not be diffed correctly.
+// The following cases are handled:
+// - A nil or empty match gets converted to {"jq": null}.
+// - A single match containing a single object gets diffed by property, with a "jq:" prefix.
+// - A match or list of matches of any other types (lists, numbers, strings) get diffed as a single "jq" property.
+func jqMatchesToBody(result []interface{}) (map[string]json.RawMessage, error) {
+	var cmp interface{}
+	switch len(result) {
+	// null
+	case 0:
+		return map[string]json.RawMessage{
+			"jq": []byte("null"),
+		}, nil
+	// object or single element
+	case 1:
+		cmp = result[0]
+		// return early if it's an object
+		obj, ok := cmp.(map[string]interface{})
+		if ok {
+			// encode every field sepearately, prefixed "jq:"
+			enc := make(map[string]json.RawMessage, len(obj))
+			for k, v := range obj {
+				val, err := json.Marshal(v)
+				if err != nil {
+					return nil, err
+				}
+				enc["jq:"+k] = val
+			}
+			return enc, nil
+		}
+	// list of elements
+	default:
+		cmp = result
+	}
+
+	// just encode it as json and assign as a special field
+	enc, err := json.Marshal(cmp)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]json.RawMessage{
+		"jq": enc,
+	}, nil
+}
+
+func runJqQuery(jq *gojq.Query, body interface{}) ([]interface{}, error) {
+	iter := jq.Run(body)
+	res := []interface{}{}
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return nil, err
+		}
+		res = append(res, v)
+	}
+	return res, nil
+}
+
+func applyJqQueryToBody(jq *gojq.Query, body interface{}) (map[string]json.RawMessage, error) {
+	res, err := runJqQuery(jq, body)
+	if err != nil {
+		return nil, err
+	}
+	return jqMatchesToBody(res)
+}

--- a/diff/jq_test.go
+++ b/diff/jq_test.go
@@ -1,0 +1,132 @@
+package diff
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_jqMatchesToBody(t *testing.T) {
+	type args struct {
+		result []interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]json.RawMessage
+		wantErr bool
+	}{
+		{
+			name: "matches list is nil",
+			args: args{
+				result: nil,
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("null"),
+			},
+		},
+		{
+			name: "matches list is empty",
+			args: args{
+				result: []interface{}{},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("null"),
+			},
+		},
+		{
+			name: "matches list contains a single object",
+			args: args{
+				result: []interface{}{
+					map[string]interface{}{
+						"null":   nil,
+						"bool":   true,
+						"number": 42.42,
+						"string": "artes serviunt vitae, sapientia imperat",
+						"list":   []interface{}{true, 42.42, "some string"},
+						"object": map[string]interface{}{"anything": 124},
+					},
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq:null":   []byte("null"),
+				"jq:bool":   []byte("true"),
+				"jq:number": []byte("42.42"),
+				"jq:string": []byte("\"artes serviunt vitae, sapientia imperat\""),
+				"jq:list":   []byte("[true,42.42,\"some string\"]"),
+				"jq:object": []byte("{\"anything\":124}"),
+			},
+		},
+		{
+			name: "matches list contains a single string",
+			args: args{
+				result: []interface{}{
+					"artes serviunt vitae, sapientia imperat",
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("\"artes serviunt vitae, sapientia imperat\""),
+			},
+		},
+		{
+			name: "matches list contains a single number",
+			args: args{
+				result: []interface{}{
+					42.42,
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("42.42"),
+			},
+		},
+		{
+			name: "matches list contains a single bool",
+			args: args{
+				result: []interface{}{
+					true,
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("true"),
+			},
+		},
+		{
+			name: "matches list contains a single list",
+			args: args{
+				result: []interface{}{
+					[]interface{}{true, 42.42, "some string"},
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("[true,42.42,\"some string\"]"),
+			},
+		},
+		{
+			name: "matches list contains a list of a values",
+			args: args{
+				result: []interface{}{
+					nil,
+					true,
+					42.42,
+					"artes serviunt vitae, sapientia imperat",
+					[]interface{}{true, 42.42, "some string"},
+					map[string]interface{}{"anything": 124},
+				},
+			},
+			want: map[string]json.RawMessage{
+				"jq": []byte("[null,true,42.42,\"artes serviunt vitae, sapientia imperat\",[true,42.42,\"some string\"],{\"anything\":124}]"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := jqMatchesToBody(tt.args.result)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("jqMatchesToBody() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -90,6 +90,10 @@ func main() {
 						Name:  "postman",
 						Usage: "~/Downloads/collection.json",
 					},
+					&cli.StringFlag{
+						Name:  "jq",
+						Usage: ".members | [] | .id",
+					},
 				},
 				Before: func(c *cli.Context) error {
 					if c.String("before") == "" {
@@ -137,6 +141,7 @@ func main() {
 						LogLevel:           c.String("loglevel"),
 						Threads:            c.Int("threads"),
 						PostmanFilePath:    c.String("postman"),
+						Jq:                 c.String("jq"),
 					})
 				},
 			},


### PR DESCRIPTION
* If --jq is specified,  passes the response bodies through a jq filter
* results from comparisons in this mode are all listed under the `jq`field if they're not valid JSON objects.