### PR TITLE
feat: Adding support to ignorerows flag

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -40,6 +40,7 @@ type Config struct {
 	LogLevel           string
 	Threads            int
 	PostmanFilePath    string
+	IgnoreRows         map[int]struct{}
 }
 
 // Cmp will compare the before and after

--- a/diff/test.go
+++ b/diff/test.go
@@ -150,6 +150,8 @@ func generateTests(ctx context.Context, c Config) (<-chan test, error) {
 
 	totalFields := h.totalFields()
 
+	shouldIgnore := len(c.IgnoreRows) > 0
+
 	// generate tests
 	out := make(chan test)
 	go func() {
@@ -174,9 +176,15 @@ func generateTests(ctx context.Context, c Config) (<-chan test, error) {
 				continue
 			}
 
-			if len(c.Rows) > 0 {
-				if _, ok := c.Rows[cursor]; !ok {
+			if shouldIgnore {
+				if _, ok := c.IgnoreRows[cursor]; ok {
 					continue
+				}
+			} else {
+				if len(c.Rows) > 0 {
+					if _, ok := c.Rows[cursor]; !ok {
+						continue
+					}
 				}
 			}
 

--- a/main.go
+++ b/main.go
@@ -90,6 +90,11 @@ func main() {
 						Name:  "postman",
 						Usage: "~/Downloads/collection.json",
 					},
+					&cli.StringFlag{
+						Name:    "ignorerows",
+						Aliases: []string{"IR"},
+						Usage:   "1,7,12 (Ignore specific tests from file)",
+					},
 				},
 				Before: func(c *cli.Context) error {
 					if c.String("before") == "" {
@@ -103,6 +108,11 @@ func main() {
 					}
 					if _, ok := validMatches[c.String("match")]; !ok {
 						return errors.New("invalid --match flag")
+					}
+					hasRows := c.String("rows") != ""
+					hasIgnoreRows := c.String("ignorerows") != ""
+					if hasIgnoreRows && hasRows {
+						return errors.New("you can't use both ignore and rows in the same time")
 					}
 					return nil
 				},
@@ -137,6 +147,7 @@ func main() {
 						LogLevel:           c.String("loglevel"),
 						Threads:            c.Int("threads"),
 						PostmanFilePath:    c.String("postman"),
+						IgnoreRows:         diff.Atoim(c.String("ignorerows")),
 					})
 				},
 			},


### PR DESCRIPTION
Today for ignore rows we need to do the opposite, which is set all the rows we want. This works pretty well when we have a small dataset, like 50, 100, 200 rows. But when we have a large dataset, like 1K rows, things get more complicated. 

So what we do is add the possibility to ignore rows using a `--ignorerows` or `-IR` flag. Using this, u can pass all the rows u want to ignore and they will be ignored. 